### PR TITLE
Offset Border by 1 Pixel to center the border lines

### DIFF
--- a/Paper/Paper.Core.cs
+++ b/Paper/Paper.Core.cs
@@ -312,7 +312,7 @@ namespace Prowl.PaperUI
             if (borderWidth > 0.0f && borderColor.A > 0)
             {
                 _canvas.BeginPath();
-                _canvas.RoundedRect(rect.x, rect.y, rect.width, rect.height, rounded.x, rounded.y, rounded.z, rounded.w);
+                _canvas.RoundedRect(rect.x-1, rect.y-1, rect.width+1, rect.height+1, rounded.x, rounded.y, rounded.z, rounded.w);
                 _canvas.SetStrokeColor(borderColor);
                 _canvas.SetStrokeWidth(borderWidth);
                 _canvas.Stroke();


### PR DESCRIPTION
When rendering borders, the borders were offset one pixel to the right and down. This resulted in incorrect border rendering, especially visible when rendering a parent item with a border and a child item with a background color. 

Before:
<img width="1228" height="523" alt="image" src="https://github.com/user-attachments/assets/14f0facb-17f9-436a-b8c3-d43291a3543a" />
After:
<img width="1225" height="523" alt="image" src="https://github.com/user-attachments/assets/045b4bda-56ba-4a66-b2b0-1671e5058fdb" />

When rendering borders with the border and background style on the same GUI object, there are no visible seams or color bleed.
<img width="1221" height="513" alt="image" src="https://github.com/user-attachments/assets/179f5522-d26b-4298-b236-d8792148de15" />
