### PR TITLE
fix: alignment issue with scroll bar and incorrect padding

### DIFF
--- a/Paper/Paper.Core.cs
+++ b/Paper/Paper.Core.cs
@@ -423,7 +423,7 @@ namespace Prowl.PaperUI
                     ? Color.FromArgb(220, 130, 130, 130)
                     : Color.FromArgb(180, 100, 100, 100);
 
-                canvas.RoundedRectFilled(trackX + ScrollState.ScrollbarPadding, thumbY, trackWidth - ScrollState.ScrollbarPadding * 2, thumbHeight, 10, 10, 10, 10, thumbColor);
+                canvas.RoundedRectFilled(trackX + ScrollState.ScrollbarPadding, thumbY + ScrollState.ScrollbarPadding, trackWidth - ScrollState.ScrollbarPadding * 2, thumbHeight - ScrollState.ScrollbarPadding * 2, 10, 10, 10, 10, thumbColor);
             }
 
             if (hasHorizontal)
@@ -438,7 +438,7 @@ namespace Prowl.PaperUI
                     ? Color.FromArgb(220, 130, 130, 130)
                     : Color.FromArgb(180, 100, 100, 100);
 
-                canvas.RoundedRectFilled(thumbX, trackY + ScrollState.ScrollbarPadding, thumbWidth, trackHeight - ScrollState.ScrollbarPadding * 2, 10, 10, 10, 10, thumbColor);
+                canvas.RoundedRectFilled(thumbX + ScrollState.ScrollbarPadding, trackY + ScrollState.ScrollbarPadding, thumbWidth, trackHeight - ScrollState.ScrollbarPadding * 2, 10, 10, 10, 10, thumbColor);
             }
         }
 


### PR DESCRIPTION
This pull requests fixes a small padding issue in the scrollbar that causes the top/bottom for vertical bars and left/right for horizontal bars to have 0 padding. 

Before
<img width="464" height="439" alt="image" src="https://github.com/user-attachments/assets/c2b73846-9fdc-4010-a787-a88810f2d330" />
<img width="406" height="325" alt="image" src="https://github.com/user-attachments/assets/bfab92ee-cec0-4306-93d3-1cdd68b8de0b" />

After
<img width="485" height="443" alt="image" src="https://github.com/user-attachments/assets/fdff5c21-f229-4679-b84b-aec6bd5bad8f" />
<img width="372" height="370" alt="image" src="https://github.com/user-attachments/assets/a6cb58fe-1ad9-4bd5-9bad-e82db94d7de8" />
<img width="421" height="422" alt="image" src="https://github.com/user-attachments/assets/695ec693-7d45-4602-ba4f-f8956d5def51" />
