### PR TITLE
fix: added font atlas settings to paper OpenTK sample

### DIFF
--- a/Samples/OpenTK/PaperTKWindow.cs
+++ b/Samples/OpenTK/PaperTKWindow.cs
@@ -19,7 +19,7 @@ namespace OpenTKSample
             base.OnLoad();
             _renderer = new PaperRenderer();
             _renderer.Initialize(ClientRectangle.Size.X, ClientRectangle.Size.Y);
-            P = new Paper(_renderer, ClientRectangle.Size.X, ClientRectangle.Size.Y);
+            P = new Paper(_renderer, ClientRectangle.Size.X, ClientRectangle.Size.Y, new Prowl.Quill.FontAtlasSettings());
             Shared.PaperDemo.Initialize(P);
         }
 


### PR DESCRIPTION
The OpenTK sample needed `new Prowl.Quill.FontAtlasSettings()` in order to load. 

The settings were added to allow the OpenTK sample to build properly.