### PR TITLE
Fix letterSpacing using GuiProp.FontSize instead of GuiProp.LetterSpacing

### DIFF
--- a/Paper/ElementBuilder.cs
+++ b/Paper/ElementBuilder.cs
@@ -2154,7 +2154,7 @@ namespace Prowl.PaperUI
             {
                 // Single-line horizontal scrolling only
                 var fontSize = (double)_handle.Data._elementStyle.GetValue(GuiProp.FontSize);
-                var letterSpacing = (double)_handle.Data._elementStyle.GetValue(GuiProp.FontSize);
+                var letterSpacing = (double)_handle.Data._elementStyle.GetValue(GuiProp.LetterSpacing);
                 var cursorPos = GetCursorPositionFromIndex(state.Value, settings.Font, fontSize, letterSpacing, state.CursorPosition);
                 
                 double visibleWidth = _handle.Data.LayoutWidth;


### PR DESCRIPTION
This looked a bit suspicious when I first saw it, but after some poking around, I still don't know how `letterSpacing` actually affects the resulting cursor position. The result seems correct regardless of what `letterSpacing` value I use.

I'm opening this PR as a way to track this issue since I don't know if this actually fixes anything.