### PR TITLE
Use int for element ids instead of ulong

### DIFF
--- a/Paper/LayoutEngine/ElementData.cs
+++ b/Paper/LayoutEngine/ElementData.cs
@@ -7,7 +7,7 @@ namespace Prowl.PaperUI.LayoutEngine
 {
     public struct ElementData
     {
-        public ulong ID;
+        public int ID;
 
         // Events
         public bool IsFocusable;
@@ -43,13 +43,13 @@ namespace Prowl.PaperUI.LayoutEngine
         // Hierarchy
         public int ParentIndex;
         public List<int> ChildIndices;
-        
+
         // Interaction hooking - whether this element inherits parent's interaction state
         public bool IsHookedToParent;
-        
+
         // Interaction hooking - whether this element has hooked children (optimization flag)
         public bool IsAHookedParent;
-        
+
         // Tab navigation - element's position in tab order (-1 means not focusable via tab)
         public int TabIndex;
 
@@ -96,7 +96,7 @@ namespace Prowl.PaperUI.LayoutEngine
 
         public readonly Rect LayoutRect => new Rect(X, Y, LayoutWidth, LayoutHeight);
 
-        public static ElementData Create(ulong id)
+        public static ElementData Create(int id)
         {
             return new ElementData
             {

--- a/Paper/Paper.Core.cs
+++ b/Paper/Paper.Core.cs
@@ -17,10 +17,10 @@ namespace Prowl.PaperUI
         // Layout and hierarchy management
         private ElementHandle _rootElementHandle;
         internal Stack<ElementHandle> _elementStack = new Stack<ElementHandle>();
-        private readonly Stack<ulong> _IDStack = new();
-        private readonly HashSet<ulong> _createdElements = [];
+        private readonly Stack<int> _IDStack = new();
+        private readonly HashSet<int> _createdElements = [];
 
-        private readonly Dictionary<ulong, Hashtable> _storage = [];
+        private readonly Dictionary<int, Hashtable> _storage = [];
 
         // Rendering context
         private Canvas _canvas;
@@ -534,7 +534,7 @@ namespace Prowl.PaperUI
         /// </summary>
         /// <param name="id">The ID to search for</param>
         /// <returns>The found element or null if not found</returns>
-        public ElementHandle FindElementByID(ulong id)
+        public ElementHandle FindElementByID(int id)
         {
             var handle = FindElementHandleByID(id);
             return handle;
@@ -551,7 +551,7 @@ namespace Prowl.PaperUI
         {
             ArgumentNullException.ThrowIfNull(stringID);
 
-            ulong storageHash = (ulong)HashCode.Combine(CurrentParent.Data.ID, _IDStack.Peek(), stringID, intID, lineID);
+            int storageHash = HashCode.Combine(CurrentParent.Data.ID, _IDStack.Peek(), stringID, intID, lineID);
 
             if (!_createdElements.Add(storageHash))
                 throw new Exception($"Element already exists with this ID: {stringID}:{intID}:{lineID} = {storageHash} Parent: {CurrentParent.Data.ID}\nPlease use a different ID.");
@@ -636,9 +636,9 @@ namespace Prowl.PaperUI
         /// <summary>
         /// Pushes an ID onto the ID stack to create a new scope.
         /// </summary>
-        public void PushID(ulong id)
+        public void PushID(int id)
         {
-            _IDStack.Push((ulong)HashCode.Combine(id, _IDStack.Peek()));
+            _IDStack.Push(HashCode.Combine(id, _IDStack.Peek()));
         }
 
         /// <summary>

--- a/Paper/Paper.ElementStorage.cs
+++ b/Paper/Paper.ElementStorage.cs
@@ -18,7 +18,7 @@ namespace Prowl.PaperUI
             return ref _elements[index];
         }
 
-        public ElementHandle CreateElement(ulong id)
+        public ElementHandle CreateElement(int id)
         {
             int index;
             ElementData elementData = ElementData.Create(id);
@@ -97,7 +97,7 @@ namespace Prowl.PaperUI
         }
 
         // Helper method to find element by ID
-        public ElementHandle FindElementHandleByID(ulong id)
+        public ElementHandle FindElementHandleByID(int id)
         {
             for (int i = 0; i < _elementCount; i++)
             {
@@ -116,13 +116,13 @@ namespace Prowl.PaperUI
                     continue;
 
                 ref var element = ref _elements[i];
-                
+
                 // Validate parent-child relationships
                 if (element.ParentIndex != -1)
                 {
                     if (element.ParentIndex < 0 || element.ParentIndex >= _elementCount)
                         throw new InvalidOperationException($"Element {i} has invalid parent index {element.ParentIndex}");
-                    
+
                     ref var parent = ref _elements[element.ParentIndex];
                     if (!parent.ChildIndices.Contains(i))
                         throw new InvalidOperationException($"Element {i} claims parent {element.ParentIndex} but parent doesn't list it as child");
@@ -132,7 +132,7 @@ namespace Prowl.PaperUI
                 {
                     if (childIndex < 0 || childIndex >= _elementCount)
                         throw new InvalidOperationException($"Element {i} has invalid child index {childIndex}");
-                    
+
                     ref var child = ref _elements[childIndex];
                     if (child.ParentIndex != i)
                         throw new InvalidOperationException($"Element {i} claims child {childIndex} but child doesn't reference it as parent");

--- a/Paper/Paper.Interaction.cs
+++ b/Paper/Paper.Interaction.cs
@@ -11,22 +11,22 @@ namespace Prowl.PaperUI
         /// <summary>
         /// Checks if an element is currently hovered.
         /// </summary>
-        public bool IsElementHovered(ulong id) => _elementsInBubblePath.Contains(id) || IsHookedToHoveredParent(id);
+        public bool IsElementHovered(int id) => _elementsInBubblePath.Contains(id) || IsHookedToHoveredParent(id);
 
         /// <summary>
         /// Checks if an element is currently active (pressed).
         /// </summary>
-        public bool IsElementActive(ulong id) => _activeElementId == id || IsHookedToActiveParent(id);
+        public bool IsElementActive(int id) => _activeElementId == id || IsHookedToActiveParent(id);
 
         /// <summary>
         /// Checks if an element has input focus.
         /// </summary>
-        public bool IsElementFocused(ulong id) => _focusedElementId == id || IsHookedToFocusedParent(id);
+        public bool IsElementFocused(int id) => _focusedElementId == id || IsHookedToFocusedParent(id);
 
         /// <summary>
         /// Checks if an element is currently being dragged.
         /// </summary>
-        public bool IsElementDragging(ulong id) =>
+        public bool IsElementDragging(int id) =>
             (_isDragging.TryGetValue(id, out bool isDragging) && isDragging) || IsHookedToDraggingParent(id);
 
         /// <summary>
@@ -56,7 +56,7 @@ namespace Prowl.PaperUI
         /// <summary>
         /// Checks if an element is hooked to its parent's hover state.
         /// </summary>
-        private bool IsHookedToHoveredParent(ulong childId)
+        private bool IsHookedToHoveredParent(int childId)
         {
             ElementHandle childElement = FindElementByID(childId);
             if (!childElement.IsValid) return false;
@@ -73,7 +73,7 @@ namespace Prowl.PaperUI
         /// <summary>
         /// Checks if an element is hooked to its parent's active state.
         /// </summary>
-        private bool IsHookedToActiveParent(ulong childId)
+        private bool IsHookedToActiveParent(int childId)
         {
             ElementHandle childElement = FindElementByID(childId);
             if (!childElement.IsValid) return false;
@@ -90,7 +90,7 @@ namespace Prowl.PaperUI
         /// <summary>
         /// Checks if an element is hooked to its parent's focus state.
         /// </summary>
-        private bool IsHookedToFocusedParent(ulong childId)
+        private bool IsHookedToFocusedParent(int childId)
         {
             ElementHandle childElement = FindElementByID(childId);
             if (!childElement.IsValid) return false;
@@ -107,7 +107,7 @@ namespace Prowl.PaperUI
         /// <summary>
         /// Checks if an element is hooked to its parent's dragging state.
         /// </summary>
-        private bool IsHookedToDraggingParent(ulong childId)
+        private bool IsHookedToDraggingParent(int childId)
         {
             ElementHandle childElement = FindElementByID(childId);
             if (!childElement.IsValid) return false;
@@ -129,20 +129,20 @@ namespace Prowl.PaperUI
         private const float DRAG_THRESHOLD = 5.0f; // pixels
 
         // Element interaction state tracking
-        private ulong _theHoveredElementId = 0;  // The ID of the element directly hovered by the pointer
-        private ulong _activeElementId = 0;      // Currently active (pressed) element
-        private ulong _focusedElementId = 0;     // Element with input focus
+        private int _theHoveredElementId = 0;  // The ID of the element directly hovered by the pointer
+        private int _activeElementId = 0;      // Currently active (pressed) element
+        private int _focusedElementId = 0;     // Element with input focus
 
         // State tracking collections
-        private Dictionary<ulong, bool> _wasHoveredState = new Dictionary<ulong, bool>();
-        private Dictionary<ulong, Vector2> _dragStartPos = new Dictionary<ulong, Vector2>();
-        private HashSet<ulong> _elementsInBubblePath = new HashSet<ulong>();
-        private Dictionary<ulong, bool> _isDragging = new Dictionary<ulong, bool>();
+        private Dictionary<int, bool> _wasHoveredState = new Dictionary<int, bool>();
+        private Dictionary<int, Vector2> _dragStartPos = new Dictionary<int, Vector2>();
+        private HashSet<int> _elementsInBubblePath = new HashSet<int>();
+        private Dictionary<int, bool> _isDragging = new Dictionary<int, bool>();
 
         // Public access to interaction state
-        public ulong HoveredElementId => _theHoveredElementId;
-        public ulong ActiveElementId => _activeElementId;
-        public ulong FocusedElementId => _focusedElementId;
+        public int HoveredElementId => _theHoveredElementId;
+        public int ActiveElementId => _activeElementId;
+        public int FocusedElementId => _focusedElementId;
 
         public bool WantsCapturePointer => _theHoveredElementId != 0 || _activeElementId != 0;
 
@@ -159,7 +159,7 @@ namespace Prowl.PaperUI
         {
             // Reset hover state
             _elementsInBubblePath.Clear();
-            ulong previousHoveredElementId = _theHoveredElementId;
+            int previousHoveredElementId = _theHoveredElementId;
             _theHoveredElementId = 0;
 
             // Find the topmost element under the pointer
@@ -333,7 +333,7 @@ namespace Prowl.PaperUI
         private void PropagateEventToHookedChildren(in ElementHandle element, Action<ElementHandle> eventHandler)
         {
             ref ElementData data = ref element.Data;
-            
+
             // Early exit optimization - if this element has no hooked children, skip entirely
             if (!data.IsAHookedParent)
                 return;
@@ -360,10 +360,10 @@ namespace Prowl.PaperUI
         /// <summary>
         /// Handles hover, enter, and leave events.
         /// </summary>
-        private void HandleHoverEvents(ulong previousHoveredElementId)
+        private void HandleHoverEvents(int previousHoveredElementId)
         {
             // Find elements that were previously hovered but are no longer in bubble path
-            var leftElements = new HashSet<ulong>(_wasHoveredState.Keys);
+            var leftElements = new HashSet<int>(_wasHoveredState.Keys);
             leftElements.ExceptWith(_elementsInBubblePath);
 
             // Trigger leave events
@@ -376,7 +376,7 @@ namespace Prowl.PaperUI
                     if (data.OnLeave != null)
                     {
                         data.OnLeave(new ElementEvent(leftElement, data.LayoutRect, PointerPos));
-                        
+
                         // Propagate leave event to hooked children
                         PropagateEventToHookedChildren(leftElement, child => {
                             ref ElementData childData = ref child.Data;
@@ -400,7 +400,7 @@ namespace Prowl.PaperUI
                     if (!wasHovered && data.OnEnter != null)
                     {
                         data.OnEnter(new ElementEvent(hoveredElement, data.LayoutRect, PointerPos));
-                        
+
                         // Propagate enter event to hooked children
                         PropagateEventToHookedChildren(hoveredElement, child => {
                             ref ElementData childData = ref child.Data;
@@ -410,7 +410,7 @@ namespace Prowl.PaperUI
 
                     // Always trigger hover event
                     data.OnHover?.Invoke(new ElementEvent(hoveredElement, data.LayoutRect, PointerPos));
-                    
+
                     // Propagate hover event to hooked children
                     PropagateEventToHookedChildren(hoveredElement, child => {
                         ref ElementData childData = ref child.Data;
@@ -461,7 +461,7 @@ namespace Prowl.PaperUI
                             if (_focusedElementId != _activeElementId)
                             {
                                 data.OnFocusChange?.Invoke(new FocusEvent(activeElement, true));
-                                
+
                                 // Propagate focus gain to hooked children
                                 PropagateEventToHookedChildren(activeElement, child => {
                                     ref ElementData childData = ref child.Data;
@@ -475,7 +475,7 @@ namespace Prowl.PaperUI
                                     {
                                         ref ElementData oldData = ref oldFocusedElement.Data;
                                         oldData.OnFocusChange?.Invoke(new FocusEvent(oldFocusedElement, false));
-                                        
+
                                         // Propagate focus loss to hooked children
                                         PropagateEventToHookedChildren(oldFocusedElement, child => {
                                             ref ElementData childData = ref child.Data;
@@ -647,13 +647,13 @@ namespace Prowl.PaperUI
                         if (!wasDragging && distanceMoved >= DRAG_THRESHOLD)
                         {
                             data.OnDragStart?.Invoke(new DragEvent(activeElement, layoutRect, PointerPos, startPos, PointerDelta, PointerDelta));
-                            
+
                             // Propagate drag start to hooked children
                             PropagateEventToHookedChildren(activeElement, child => {
                                 ref ElementData childData = ref child.Data;
                                 childData.OnDragStart?.Invoke(new DragEvent(child, childData.LayoutRect, PointerPos, startPos, PointerDelta, PointerDelta));
                             });
-                            
+
                             BubbleEventToParents(activeElement, parent => {
                                 ref ElementData parentData = ref parent.Data;
                                 parentData.OnDragStart?.Invoke(new DragEvent(parent, parentData.LayoutRect, PointerPos, startPos, PointerDelta, PointerDelta));
@@ -664,13 +664,13 @@ namespace Prowl.PaperUI
 
                         // Handle continuous dragging
                         data.OnDragging?.Invoke(new DragEvent(activeElement, layoutRect, PointerPos, startPos, PointerDelta, PointerDelta));
-                        
+
                         // Propagate dragging to hooked children
                         PropagateEventToHookedChildren(activeElement, child => {
                             ref ElementData childData = ref child.Data;
                             childData.OnDragging?.Invoke(new DragEvent(child, childData.LayoutRect, PointerPos, startPos, PointerDelta, PointerDelta));
                         });
-                        
+
                         BubbleEventToParents(activeElement, parent => {
                             ref ElementData parentData = ref parent.Data;
                             parentData.OnDragging?.Invoke(new DragEvent(parent, parentData.LayoutRect, PointerPos, startPos, PointerDelta, PointerDelta));
@@ -737,8 +737,8 @@ namespace Prowl.PaperUI
         private void HandleTabNavigation()
         {
             // Get all elements with valid tab indices
-            var tabbableElements = new List<(int tabIndex, ulong elementId)>();
-            
+            var tabbableElements = new List<(int tabIndex, int elementId)>();
+
             // Brute force search through all elements
             for (int i = 0; i < _elementCount; i++)
             {
@@ -756,7 +756,7 @@ namespace Prowl.PaperUI
             // Sort by tab index
             tabbableElements.Sort((a, b) => a.tabIndex.CompareTo(b.tabIndex));
 
-            ulong nextElementId;
+            int nextElementId;
 
             if (_focusedElementId == 0)
             {
@@ -801,7 +801,7 @@ namespace Prowl.PaperUI
                     {
                         ref ElementData oldData = ref oldFocusedElement.Data;
                         oldData.OnFocusChange?.Invoke(new FocusEvent(oldFocusedElement, false));
-                        
+
                         // Propagate focus loss to hooked children
                         PropagateEventToHookedChildren(oldFocusedElement, child => {
                             ref ElementData childData = ref child.Data;
@@ -813,7 +813,7 @@ namespace Prowl.PaperUI
                 _focusedElementId = nextElementId;
                 ref ElementData nextData = ref nextElement.Data;
                 nextData.OnFocusChange?.Invoke(new FocusEvent(nextElement, true));
-                
+
                 // Propagate focus gain to hooked children
                 PropagateEventToHookedChildren(nextElement, child => {
                     ref ElementData childData = ref child.Data;

--- a/Paper/Paper.Styles.cs
+++ b/Paper/Paper.Styles.cs
@@ -754,7 +754,7 @@ namespace Prowl.PaperUI
         /// <summary>
         /// A dictionary to keep track of active styles for each element.
         /// </summary>
-        Dictionary<ulong, ElementStyle> _activeStyles = new();
+        Dictionary<int, ElementStyle> _activeStyles = new();
 
         /// <summary>
         /// Update the styles for all active elements.
@@ -763,7 +763,7 @@ namespace Prowl.PaperUI
         /// <param name="element">The root element to start updating from.</param>
         private void UpdateStyles(double deltaTime, ElementHandle element)
         {
-            ulong id = element.Data.ID;
+            int id = element.Data.ID;
             if (_activeStyles.TryGetValue(id, out var style))
             {
                 // Update the style properties
@@ -789,7 +789,7 @@ namespace Prowl.PaperUI
         /// <summary>
         /// Set a style property value (no transition).
         /// </summary>
-        internal void SetStyleProperty(ulong elementID, GuiProp property, object value)
+        internal void SetStyleProperty(int elementID, GuiProp property, object value)
         {
             if (!_activeStyles.TryGetValue(elementID, out var style))
             {
@@ -805,7 +805,7 @@ namespace Prowl.PaperUI
         /// <summary>
         /// Configure a transition for a property.
         /// </summary>
-        internal void SetTransitionConfig(ulong elementID, GuiProp property, double duration, Func<double, double>? easing = null)
+        internal void SetTransitionConfig(int elementID, GuiProp property, double duration, Func<double, double>? easing = null)
         {
             if (!_activeStyles.TryGetValue(elementID, out var style))
             {
@@ -821,10 +821,10 @@ namespace Prowl.PaperUI
         /// <summary>
         /// Clean up styles at the end of a frame.
         /// </summary>
-        private void EndOfFrameCleanupStyles(HashSet<ulong> createdElements)
+        private void EndOfFrameCleanupStyles(HashSet<int> createdElements)
         {
             // Clean up any elements that haven't been accessed this frame
-            List<ulong> elementsToRemove = new List<ulong>();
+            List<int> elementsToRemove = new List<int>();
             foreach (var kvp in _activeStyles)
             {
                 if (!createdElements.Contains(kvp.Key))

--- a/Samples/Shared/PaperDemo.cs
+++ b/Samples/Shared/PaperDemo.cs
@@ -51,7 +51,7 @@ namespace Shared
                 // A stupid simple way to benchmark the performance of the UI (Adds the entire ui multiple times)
                 for (int i = 0; i < 1; i++)
                 {
-                    Gui.PushID((ulong)i);
+                    Gui.PushID(i);
                     // Top navigation bar
                     RenderTopNavBar();
 

--- a/Tests/IdTests.cs
+++ b/Tests/IdTests.cs
@@ -12,7 +12,7 @@ public class IdTests
     [Theory]
     [InlineData(0)]
     [InlineData(1)]
-    public void PushID_PreventsException_WhenDuplicateIdsAreAdded(ulong id)
+    public void PushID_PreventsException_WhenDuplicateIdsAreAdded(int id)
     {
         var paper = new Paper(new Renderer(), 1, 1, new FontAtlasSettings());
 

--- a/Tests/IdTests.cs
+++ b/Tests/IdTests.cs
@@ -16,16 +16,16 @@ public class IdTests
     {
         var paper = new Paper(new Renderer(), 1, 1, new FontAtlasSettings());
 
-        // This test explicitly provides the intID so that the ID stack can be tested independently
+        // This test explicitly provides the intID and lineID so that the ID stack can be tested independently
         paper.BeginFrame(0);
         {
             paper.PushID(id);
             {
-                paper.Box("Element", 0);
+                paper.Box("Element", 0, 0);
 
                 paper.PushID(id);
                 {
-                    paper.Box("Element", 0);
+                    paper.Box("Element", 0, 0);
                 }
                 paper.PopID();
             }


### PR DESCRIPTION
This will close #20

This should include all cases where an element ID is used.
I ran a quick search over the codebase and the only place remaining where `ulong` is used is in `ArrayBuffer`, which is unrelated to element IDs.