### PR TITLE
Change text input to not internally store text value

### DIFF
--- a/Paper/ElementBuilder.cs
+++ b/Paper/ElementBuilder.cs
@@ -1709,7 +1709,7 @@ namespace Prowl.PaperUI
         public ElementBuilder TextField(
             string value,
             TextInputSettings settings,
-            Action<string> onChange = null,
+            Action<string> onChange,
             [System.Runtime.CompilerServices.CallerLineNumber] int intID = 0)
         {
             return CreateTextInput(value, settings, onChange, false, intID);
@@ -1730,7 +1730,7 @@ namespace Prowl.PaperUI
         public ElementBuilder TextField(
             string value,
             FontFile font,
-            Action<string> onChange = null,
+            Action<string> onChange,
             Color? textColor = null,
             string placeholder = "",
             Color? placeholderColor = null,
@@ -1756,7 +1756,7 @@ namespace Prowl.PaperUI
         public ElementBuilder TextArea(
             string value,
             TextInputSettings settings,
-            Action<string> onChange = null,
+            Action<string> onChange,
             [System.Runtime.CompilerServices.CallerLineNumber] int intID = 0)
         {
             return CreateTextInput(value, settings, onChange, true, intID);
@@ -1777,7 +1777,7 @@ namespace Prowl.PaperUI
         public ElementBuilder TextArea(
             string value,
             FontFile font,
-            Action<string> onChange = null,
+            Action<string> onChange,
             string placeholder = "",
             Color? textColor = null,
             Color? placeholderColor = null,
@@ -1959,7 +1959,7 @@ namespace Prowl.PaperUI
                 SaveTextInputState(currentState);
                 
                 if (valueChanged)
-                    onChange?.Invoke(currentState.Value);
+                    onChange.Invoke(currentState.Value);
             });
         
             // Handle character input
@@ -1983,7 +1983,7 @@ namespace Prowl.PaperUI
                 
                 EnsureCursorVisible(ref currentState, settings, isMultiLine);
                 SaveTextInputState(currentState);
-                onChange?.Invoke(currentState.Value);
+                onChange.Invoke(currentState.Value);
             });
 
             // Render cursor and selection

--- a/Samples/Shared/PaperDemo.Components.cs
+++ b/Samples/Shared/PaperDemo.Components.cs
@@ -158,7 +158,7 @@ namespace Shared
                 .Register();
         }
 
-        public static ElementBuilder Secondary(string stringID, string value, Action<string> onChange = null, string placeholder = "", int intID = 0, [CallerLineNumber] int lineID = 0)
+        public static ElementBuilder Secondary(string stringID, string value, Action<string> onChange, string placeholder = "", int intID = 0, [CallerLineNumber] int lineID = 0)
         {
             ElementBuilder parent = PaperDemo.Gui.Box(stringID, intID, lineID).Style("shadcs-text-field-secondary").TabIndex(0);
             using (parent.Enter())


### PR DESCRIPTION
This ensures that the value used is the value provided, which allows for better control.
The original behavior just caches the value internally, which makes it hard to change the text value from code unless doing something hacky like changing the ID.

This also means that in order to have text inputs work, the developer needs to implement the callback, but this is reasonable and provides better control:
```cs
// From PaperDemo

// No callback
// This prevents the user from changing the text field
Input.Secondary("SearchTextField", searchText)

// Also prevents user from changing the text field
Input.Secondary("SearchTextField", searchText, newValue => {}, "Search...")
```

This is a change that I made a while ago in my fork, but didn't make a PR for since it's somewhat of a hacky solution.

I'm opening this now since Zed had the same issue as me in the Discord. I plan to improve on this a bit more in the future (look into alternative way of setting the text value; ~~maybe make the callback required~~ done).