### PR TITLE
Fixed cursor position in text fields

### DIFF
--- a/Paper/ElementBuilder.cs
+++ b/Paper/ElementBuilder.cs
@@ -2066,8 +2066,8 @@ namespace Prowl.PaperUI
                         {
                             var textLayout = _paper.CreateLayout(renderState.Value, layoutSettings);
                             var cursorPos = textLayout.GetCursorPosition(renderState.CursorPosition);
-                            float cursorX = r.Min.X + cursorPos.X;
-                            float cursorY = r.Min.Y + cursorPos.Y;
+                            float cursorX = r.Min.X + cursorPos.X / canvas.Scale;
+                            float cursorY = r.Min.Y + cursorPos.Y / canvas.Scale;
 
                             canvas.BeginPath();
                             canvas.MoveTo(cursorX, cursorY);


### PR DESCRIPTION
Previously, the cursor position would gradually be offset the more characters were input into a textfield. The issue was fixed by dividing the cursor position by the canvas scale.